### PR TITLE
refactor: Change lockfile implementation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -416,6 +416,8 @@ func (s *Shed) List(ctx context.Context, opts ListOptions) ([]ToolInfo, error) {
 		select {
 		case r := <-resultCh:
 			if r.err != nil {
+				// Stop any update checks that are still in progress
+				cancel()
 				return nil, r.err
 			}
 			tools = append(tools, r.info)


### PR DESCRIPTION
Change the lockfile implementation to store all tools in a slice and keep a map of binary names to slices of tool indices. This generally makes the implementation way simpler, especially when it comes it iterating over the lockfile as it is now just iterating over a slice. It comes at the cost of requiring slightly more space, but I believe this tradeoff is well worth the benefits in simplicity and performance.